### PR TITLE
Corrected regex for string as the previous only matches one letter st…

### DIFF
--- a/Tokenizer.cpp
+++ b/Tokenizer.cpp
@@ -14,7 +14,7 @@ vector<token> Tokenizer::tokenize(string &input)
         {"PLUS", R"(\+)"},
         {"SEMICOLON", R"(;)"},
         {"WHITESPACE", R"(\s+)"},
-        {"STRING", R"("[a-zA-Z]")"},
+        {"STRING", R"(".*?")"},
         {"CHAR", R"('([a-zA-Z])')"},
     };
 


### PR DESCRIPTION
The previous regex for string "[a-zA-Z]" only matches one character. The corrected regex R"(".*")" will match full strings.


